### PR TITLE
New --min_following AND --unfollow_any

### DIFF
--- a/insomniac.py
+++ b/insomniac.py
@@ -94,10 +94,10 @@ def main():
                                  on_interaction)
         elif mode == Mode.UNFOLLOW:
             ## added min_following to _job_unfollow
-            _job_unfollow(device, int(args.unfollow), storage, int(args.min_following), only_non_followers=False)
+            _job_unfollow(device, int(args.unfollow), storage, int(args.min_following), int(args.unfollow_any), only_non_followers=False)
         elif mode == Mode.UNFOLLOW_NON_FOLLOWERS:
             ## added min_following to _job_unfollow
-            _job_unfollow(device, int(args.unfollow_non_followers), storage, int(args.min_following), only_non_followers=True)
+            _job_unfollow(device, int(args.unfollow_non_followers), storage, int(args.unfollow_any), only_non_followers=True)
 
         close_instagram(device_id)
         print_copyright(session_state.my_username)
@@ -173,7 +173,7 @@ def _job_handle_bloggers(device,
             break
 
 ## added min_following to _job_unfollow
-def _job_unfollow(device, count, storage, min_following, only_non_followers):
+def _job_unfollow(device, count, storage, min_following, unfollow_any, only_non_followers):
     class State:
         def __init__(self):
             pass
@@ -198,7 +198,7 @@ def _job_unfollow(device, count, storage, min_following, only_non_followers):
                  on_unfollow,
                  storage,
                  only_non_followers,
-                 session_state.my_username, current_following_count, min_following)
+                 session_state.my_username, current_following_count, min_following, unfollow_any)
         print("Unfollowed " + str(state.unfollowed_count) + ", finish.")
         state.is_job_completed = True
 
@@ -252,6 +252,10 @@ def _parse_arguments():
                         default='0')
     parser.add_argument('--min_following',
                         help='Minimum amount of followings, once reached this amount then unfollow would stop',
+                        metavar='100',
+                        default='0')
+    parser.add_argument('--unfollow_any',
+                        help='Skips followed/not_followed by script validation',
                         metavar='100',
                         default='0')
     parser.add_argument('--device',

--- a/src/action_get_my_profile_info.py
+++ b/src/action_get_my_profile_info.py
@@ -47,3 +47,19 @@ def _get_followers_count(device):
         print(COLOR_FAIL + "Cannot find your followers count view" + COLOR_ENDC)
 
     return followers
+
+# Gets Followig Count
+def _get_following_count(device):
+    following = None
+    following_text_view = device(resourceId='com.instagram.android:id/row_profile_header_textview_following_count',
+                                 className='android.widget.TextView')
+    if following_text_view.exists:
+        following_text = following_text_view.text
+        if following_text:
+            following = parse(device, following_text)
+        else:
+            print(COLOR_FAIL + "Cannot get your following count text" + COLOR_ENDC)
+    else:
+        print(COLOR_FAIL + "Cannot find your following count view" + COLOR_ENDC)
+
+    return following

--- a/src/action_unfollow.py
+++ b/src/action_unfollow.py
@@ -1,11 +1,13 @@
 from src.storage import FollowingStatus
 from src.utils import *
 
-
-def unfollow(device, count, on_unfollow, storage, only_non_followers, my_username):
+#
+## added min_following and following_count to unfollow function
+def unfollow(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following):
     _open_my_followings(device)
     _sort_followings_by_date(device)
-    _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username)
+    ## added min_following and following_count to _iterate_over_followings function
+    _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following)
 
 
 def _open_my_followings(device):
@@ -28,8 +30,23 @@ def _sort_followings_by_date(device):
     sort_options_recycler_view = device(resourceId='com.instagram.android:id/follow_list_sorting_options_recycler_view')
     sort_options_recycler_view.child(index=2).click.wait()
 
+## added min_following and following_count to _iterate_over_followings function
+def _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following):
+    
+    following_deduction = 0
+    # If following is = 0 then validate limit
+    if min_following > 0:
+        if following_count <= min_following:
+            print("\033[91mYou currently have a total of ["+ str(following_count) +"] users follorwing, the minimum assigned is ["+ str(min_following) +"], ending session....\033[37m")
+            return
+        # Calculate how many following we can remove form user
+        following_deduction = (following_count - min_following)
+        following_total = (following_count - following_deduction)
+        print("\033[96mUser Currently has ["+ str(following_count) +"] and would stop unfollowing at ["+ str(following_deduction) +"] unfollows, total user followings after job ["+ str(following_total) +"]\033[37m")
+    else:
+        print("\033[96mUser Currently has ["+ str(following_count) +"] and it would not stop unfollowing!\033[37m")
 
-def _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username):
+
     unfollowed_count = 0
     while True:
         print("Iterate over visible followings")
@@ -37,6 +54,12 @@ def _iterate_over_followings(device, count, on_unfollow, storage, only_non_follo
 
         for item in device(resourceId='com.instagram.android:id/follow_list_container',
                            className='android.widget.LinearLayout'):
+
+            # if we've reach the minimum amount of users following and min_following is more than 0, print message and exit
+            if unfollowed_count >= following_deduction and min_following > 0:
+                print("\033[96mUnfollow stopped, you have reach the minimum amount of following you could have\033[37m")
+                return
+
             user_info_view = item.child(index=1)
             user_name_view = user_info_view.child(index=0).child()
             if not user_name_view.exists:

--- a/src/action_unfollow.py
+++ b/src/action_unfollow.py
@@ -3,11 +3,11 @@ from src.utils import *
 
 #
 ## added min_following and following_count to unfollow function
-def unfollow(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following):
+def unfollow(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following, unfollow_any):
     _open_my_followings(device)
     _sort_followings_by_date(device)
     ## added min_following and following_count to _iterate_over_followings function
-    _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following)
+    _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following, unfollow_any)
 
 
 def _open_my_followings(device):
@@ -31,7 +31,7 @@ def _sort_followings_by_date(device):
     sort_options_recycler_view.child(index=2).click.wait()
 
 ## added min_following and following_count to _iterate_over_followings function
-def _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following):
+def _iterate_over_followings(device, count, on_unfollow, storage, only_non_followers, my_username, following_count, min_following, unfollow_any):
     
     following_deduction = 0
     # If following is = 0 then validate limit
@@ -45,6 +45,10 @@ def _iterate_over_followings(device, count, on_unfollow, storage, only_non_follo
         print("\033[96mUser Currently has ["+ str(following_count) +"] and would stop unfollowing at ["+ str(following_deduction) +"] unfollows, total user followings after job ["+ str(following_total) +"]\033[37m")
     else:
         print("\033[96mUser Currently has ["+ str(following_count) +"] and it would not stop unfollowing!\033[37m")
+
+    if unfollow_any > 0:
+        print("\033[96mUser unfollow_any activated, script will not validate interation with the users followed by the script!\033[37m")
+
 
 
     unfollowed_count = 0
@@ -70,7 +74,7 @@ def _iterate_over_followings(device, count, on_unfollow, storage, only_non_follo
             screen_iterated_followings += 1
 
             following_status = storage.get_following_status(username)
-            if not following_status == FollowingStatus.FOLLOWED:
+            if not following_status == FollowingStatus.FOLLOWED and unfollow_any == 0:
                 print("Skip @" + username + ". Following status: " + following_status.name + ".")
             elif only_non_followers and _check_is_follower(device, username, my_username):
                 print("Skip @" + username + ". This user is following you.")


### PR DESCRIPTION
**--unfollow_any**

Variable for unfollow not followed by the script
- Disabled by default

_Usage:_
--unfollow_any 1 (active)
--unfollow_any 0 (disabled)

_Example:_
--unfollow 100 --unfollow_any 1

----------------------------------------------------------------------------

**—min_following**

- Disabled by default

If you are following more than the —min_following the —unfollow continue and stop when you reach the —min_following

If you are following less than the —min_following the —unfollow stop

We did this thinking in to have a control to make unfollow in general and give it more time to the users, for them to follow us back.

The idea is to run the script during a certain amount of days, until reach to a cuantity of follows. Once in that amount, we will add a —min_following.

Example:

—follow_limit 100 (daily for a weak)

After a weak:

—follow_limit 100 (daily)
—unfollow 100 —min_following 700 (daily)

Now we keep always on 700 followings min and we would ensure to just do unfollow to the people that we followed the last week and the ones that we are following this week, we would give them more time to follow us back.

As we go growing more than 700 followed, we will unfollowing the followed that are more old than a week

By @P3x26 and me