### PR TITLE
Feature: add current view hierarchy to the crash zip

### DIFF
--- a/src/device_facade.py
+++ b/src/device_facade.py
@@ -64,6 +64,16 @@ class DeviceFacade:
             self.deviceV1.screenshot(path)
         else:
             self.deviceV2.screenshot(path)
+    
+    def dump_hierarchy(self, path):
+        xml_dump = ''
+        if self.deviceV1 is not None:
+            xml_dump = self.deviceV1.dump()
+        else:
+            xml_dump = self.deviceV2.dump_hierarchy()
+        
+        with open(path, 'w') as outfile:
+            outfile.write(xml_dump)
 
     class View:
         deviceV1 = None  # uiautomator

--- a/src/utils.py
+++ b/src/utils.py
@@ -85,6 +85,12 @@ def save_crash(device):
     except RuntimeError:
         print(COLOR_FAIL + "Cannot save screenshot." + COLOR_ENDC)
 
+    view_hierarchy_format = ".xml"
+    try:
+        device.dump_hierarchy("crashes/" + directory_name + "/view_hierarchy" + view_hierarchy_format)
+    except RuntimeError:
+        print(COLOR_FAIL + "Cannot save view hierarchy." + COLOR_ENDC)
+
     with open("crashes/" + directory_name + "/logs.txt", 'w') as outfile:
         outfile.write(print_log)
 


### PR DESCRIPTION
Add the current screen view hierarchy to the
crash zip file. The view hierarchy is important
when debugging an issue.

The file is named view_hierarchy.xml and has
an average size of 50 Kb uncompressed.