### PR TITLE
Fixed missing recent tab on hash tags

### DIFF
--- a/insomniac/action_handle_hashtag.py
+++ b/insomniac/action_handle_hashtag.py
@@ -154,7 +154,11 @@ def extract_hashtag_likers_and_interact(device, hashtag, iteration_callback, ite
     print("Switching to Recent tab")
     tab_layout = device.find(resourceId='com.instagram.android:id/tab_layout',
                              className='android.widget.LinearLayout')
-    tab_layout.child(index=1).click()
+
+    if tab_layout.exists():
+        tab_layout.child(index=1).click()
+    else:
+        print("Can't Find recent tab. Interacting with Popular.")
     random_sleep()
 
     # Open first post


### PR DESCRIPTION
Due to the elections, the tab bar on hashtags doesn't exist causing the code to error. This fix will allow you to interact with popular if there is no option to go to recent. If the tab bar exists it will still choose recent. 