### PR TITLE
Supporting carousel posts that start with a video

### DIFF
--- a/insomniac/actions_impl.py
+++ b/insomniac/actions_impl.py
@@ -20,7 +20,7 @@ UNFOLLOW_REGEX = 'Unfollow'
 FOLLOWING_BUTTON_ID_REGEX = '{0}:id/row_profile_header_following_container' \
                             '|{1}:id/row_profile_header_container_following'
 USER_AVATAR_VIEW_ID = '{0}:id/circular_image|^$'
-POST_VIEW_ID_REGEX = '{0}:id/zoomable_view_container|{1}:id/carousel_image'
+POST_VIEW_ID_REGEX = '{0}:id/zoomable_view_container|{1}:id/carousel_image|{2}:id/carousel_video_image'
 
 liked_count = 0
 is_followed = False


### PR DESCRIPTION
Looks like Insomniac is crashing on every carousel which is starting with a video.

Images are placed to a `id/zoomable_view_container`, carousels which start with an image are placed to a `id/carousel_image`.
But carousels that start with a video are placed to a `id/carousel_video_container`.

Looks like Issue #239 is reporting that.

This fix is untested, please triplecheck. Testing is not thrilling me. lol