### PR TITLE
Skip following users during interaction (closes #268)

### DIFF
--- a/insomniac/action_runners/interact/__init__.py
+++ b/insomniac/action_runners/interact/__init__.py
@@ -6,6 +6,8 @@ from insomniac.utils import *
 
 
 class InteractBySourceActionRunner(CoreActionsRunner):
+    DEFAULT_SKIP_FOLLOWING_USER = False
+
     ACTION_ID = "interact"
     ACTION_ARGS = {
         "likes_count": {
@@ -54,6 +56,10 @@ class InteractBySourceActionRunner(CoreActionsRunner):
             "default": [],
             "metavar": ('WOW!', 'What a picture!')
         },
+        "skip_following_user": {
+            "help": "Skip already following users, even doesn't followed by the bot",
+            "metavar": "True / false"
+        }
     }
 
     likes_count = '2'
@@ -63,6 +69,7 @@ class InteractBySourceActionRunner(CoreActionsRunner):
     stories_count = '0'
     comment_percentage = 0
     comments_list = []
+    skip_following_user = DEFAULT_SKIP_FOLLOWING_USER
 
     def is_action_selected(self, args):
         return args.interact is not None and len(args.interact) > 0
@@ -75,6 +82,7 @@ class InteractBySourceActionRunner(CoreActionsRunner):
         self.stories_count = '0'
         self.comment_percentage = 0
         self.comments_list = []
+        self.skip_following_user = self.DEFAULT_SKIP_FOLLOWING_USER
 
     def set_params(self, args):
         self.reset_params()
@@ -174,7 +182,8 @@ class InteractBySourceActionRunner(CoreActionsRunner):
                                    on_action,
                                    is_limit_reached,
                                    is_passed_filters,
-                                   self.action_status)
+                                   self.action_status,
+                                   skip_following_user=self.skip_following_user)
                 elif source.startswith("P-"):
                     source_name, instructions = extract_place_instructions(source[2:])
                     handle_place(device_wrapper.get(),

--- a/insomniac/action_runners/interact/action_handle_hashtag.py
+++ b/insomniac/action_runners/interact/action_handle_hashtag.py
@@ -53,7 +53,8 @@ def handle_hashtag(device,
                    on_action,
                    is_limit_reached,
                    is_passed_filters,
-                   action_status):
+                   action_status,
+                   skip_following_user):
     interaction_source = "#{0}".format(hashtag)
     interaction = partial(interact_with_user,
                           device=device,

--- a/insomniac/actions_impl.py
+++ b/insomniac/actions_impl.py
@@ -32,7 +32,7 @@ is_commented = False
 class InteractionStrategy(object):
     def __init__(self, do_like=False, do_follow=False, do_story_watch=False, do_comment=False,
                  likes_count=2, like_percentage=100, follow_percentage=0, stories_count=2, comment_percentage=0,
-                 comments_list=None):
+                 comments_list=None, interact_with_following_user = True):
         self.do_like = do_like
         self.do_follow = do_follow
         self.do_story_watch = do_story_watch
@@ -43,6 +43,7 @@ class InteractionStrategy(object):
         self.stories_count = stories_count
         self.comment_percentage = comment_percentage
         self.comments_list = comments_list
+        self.interact_with_following_user = interact_with_following_user
 
 
 def scroll_to_bottom(device):
@@ -256,6 +257,12 @@ def interact_with_user(device,
 
     if interaction_strategy.do_story_watch:
         is_watched = _watch_stories(device, username, interaction_strategy.stories_count, on_action)
+
+    if interaction_strategy.interact_with_following_user:
+        if is_already_followed(device):
+            print("Already following user, skip interact")
+            return liked_count == interaction_strategy.likes_count, is_followed, is_watched, is_commented
+
 
     def do_like_actions():
         global is_scrolled_down


### PR DESCRIPTION
This PR adds the possibility to users to prevent interaction with already following users even not followed by the bot.
In order to activate it's necessary to add the flag  `--skip-following-user`.
This works even with hashtags. 

