### PR TITLE
Add --speed option to manually set the speed

### DIFF
--- a/insomniac/params.py
+++ b/insomniac/params.py
@@ -48,9 +48,6 @@ def parse_arguments(all_args_dict, starter_conf_file_path):
 
         refresh_args_by_conf_file(args)
 
-    if args.speed is not None:
-        args.no_speed_check = True
-
     return True, args
 
 

--- a/insomniac/params.py
+++ b/insomniac/params.py
@@ -48,6 +48,9 @@ def parse_arguments(all_args_dict, starter_conf_file_path):
 
         refresh_args_by_conf_file(args)
 
+    if args.speed is not None:
+        args.no_speed_check = True
+
     return True, args
 
 

--- a/insomniac/session.py
+++ b/insomniac/session.py
@@ -218,13 +218,12 @@ class InsomniacSession(object):
         while True:
             self.print_session_params(args)
 
-            if not args.no_speed_check:
+            if args.speed is not None:
+                sleeper.set_random_sleep_range(args.speed)
+            elif not args.no_speed_check:
                 print("Checking your Internet speed to adjust the script speed, please wait for a minute...")
                 print("(use " + COLOR_BOLD + "--no-speed-check" + COLOR_ENDC + " to skip this check)")
                 sleeper.update_random_sleep_range()
-
-            if args.speed is not None:
-                sleeper.set_random_sleep_range(args.speed)
 
             device_wrapper, app_version = self.get_device_wrapper(args)
             if device_wrapper is None:

--- a/insomniac/session.py
+++ b/insomniac/session.py
@@ -39,6 +39,12 @@ class InsomniacSession(object):
             'help': 'skip internet speed check at start',
             'action': 'store_true'
         },
+        "speed": {
+            'help': 'manually specify the speed setting, from 1 (slowest) to 4 (fastest)',
+            'metavar': '1-4',
+            'type': int,
+            'choices': range(1, 5)
+        },
         "no_typing": {
             'help': 'disable "typing" feature (typing symbols one-by-one as a human)',
             'action': 'store_true'
@@ -216,6 +222,9 @@ class InsomniacSession(object):
                 print("Checking your Internet speed to adjust the script speed, please wait for a minute...")
                 print("(use " + COLOR_BOLD + "--no-speed-check" + COLOR_ENDC + " to skip this check)")
                 sleeper.update_random_sleep_range()
+
+            if args.speed is not None:
+                sleeper.set_random_sleep_range(args.speed)
 
             device_wrapper, app_version = self.get_device_wrapper(args)
             if device_wrapper is None:

--- a/insomniac/sleeper.py
+++ b/insomniac/sleeper.py
@@ -29,6 +29,36 @@ class Sleeper:
         print(f"Sleep for {delay:.2f} seconds")
         sleep(delay)
 
+    def _set_random_sleep_range(self, speed, s1, s2):
+        start1, end1 = SLEEP_RANGE_BY_SPEED[s1]
+        start2, end2 = SLEEP_RANGE_BY_SPEED[s2]
+        x = (speed - s1) / (s2 - s1) if s2 != s1 else 1  # x is a value between [0, 1]
+
+        self.sleep_range_start = start1 + x * (start2 - start1)
+        self.sleep_range_end = end1 + x * (end2 - end1)
+
+        print(f"Sleep range will be from {self.sleep_range_start:.2f} to {self.sleep_range_end:.2f} seconds")
+
+    def set_random_sleep_range(self, speed_1_to_4):
+        if speed_1_to_4 == 1:
+            s1 = SPEED_ZERO
+            s2 = SPEED_UGLY
+            speed = SPEED_ZERO
+        elif speed_1_to_4 == 2:
+            s1 = SPEED_UGLY
+            s2 = SPEED_BAD
+            speed = SPEED_UGLY
+        elif speed_1_to_4 == 3:
+            s1 = SPEED_BAD
+            s2 = SPEED_GOOD
+            speed = SPEED_BAD
+        else:
+            s1 = SPEED_GOOD
+            s2 = SPEED_GOOD
+            speed = SPEED_GOOD
+
+        self._set_random_sleep_range(speed, s1, s2)
+
     def update_random_sleep_range(self):
         speed = _get_internet_speed()
         if SPEED_ZERO <= speed <= SPEED_UGLY:
@@ -44,15 +74,7 @@ class Sleeper:
             s1 = SPEED_GOOD
             s2 = SPEED_GOOD
 
-        start1, end1 = SLEEP_RANGE_BY_SPEED[s1]
-        start2, end2 = SLEEP_RANGE_BY_SPEED[s2]
-        x = (speed - s1) / (s2 - s1) if s2 != s1 else 1  # x is a value between [0, 1]
-
-        self.sleep_range_start = start1 + x * (start2 - start1)
-        self.sleep_range_end = end1 + x * (end2 - end1)
-
-        print(f"Sleep range will be from {self.sleep_range_start:.2f} to {self.sleep_range_end:.2f} seconds")
-
+        self._set_random_sleep_range(speed, s1, s2)
 
 def _get_internet_speed():
     from insomniac.tools import speedtest


### PR DESCRIPTION
This addresses issue #325 by allowing the user to skip the speed test if they already know the appropriate setting. 

If you're using a slow emulator on a fast internet connection, the speed test sets Insomniac to run too fast, resulting in crashes and spurious softban warnings. With this PR you can manually set the speed and skip the speed test altogether.